### PR TITLE
Enhancements to allow run agent on Windows and with Tomcat.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ nbactions.xml
 nb-configuration.xml
 target/
 dependency-reduced-pom.xml
+.idea/
+*.iml

--- a/metrics-agent-core/src/main/java/com/fleury/metrics/agent/config/Args.java
+++ b/metrics-agent-core/src/main/java/com/fleury/metrics/agent/config/Args.java
@@ -17,6 +17,6 @@ public class Args {
             return System.getProperty("agent-config");
         }
 
-        return agentArgs.split(":")[1];
+        return agentArgs.substring(agentArgs.indexOf(':') + 1);
     }
 }

--- a/metrics-agent-core/src/main/java/com/fleury/metrics/agent/model/Metric.java
+++ b/metrics-agent-core/src/main/java/com/fleury/metrics/agent/model/Metric.java
@@ -62,4 +62,15 @@ public class Metric {
     public void setExt(Map<String, String> ext) {
         this.ext = ext;
     }
+
+    @Override
+    public String toString() {
+        return "Metric{" +
+                "type=" + type +
+                ", name='" + name + '\'' +
+                ", doc='" + doc + '\'' +
+                ", labels=" + labels +
+                ", ext=" + ext +
+                '}';
+    }
 }

--- a/metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/AnnotatedMetricClassTransformer.java
+++ b/metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/AnnotatedMetricClassTransformer.java
@@ -8,13 +8,15 @@ import java.security.ProtectionDomain;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author Will Fleury
  */
 public class AnnotatedMetricClassTransformer implements ClassFileTransformer {
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(AnnotatedMetricClassTransformer.class);
     private final Configuration config;
 
     public AnnotatedMetricClassTransformer(Configuration config) {
@@ -25,14 +27,19 @@ public class AnnotatedMetricClassTransformer implements ClassFileTransformer {
     public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
             ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
 
-        ClassReader cr = new ClassReader(classfileBuffer);
-        ClassWriter cw = new ClassWriter(cr, ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+        if (config.inWhiteList(className)) {
+            LOGGER.debug("Class found in the white list: " + className);
+            ClassReader cr = new ClassReader(classfileBuffer);
+            ClassWriter cw = new ClassWriter(cr, ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
 
-        ClassVisitor cv = new MetricClassVisitor(config, cw);
+            ClassVisitor cv = new MetricClassVisitor(config, cw);
 
-        cr.accept(cv, ClassReader.EXPAND_FRAMES);
+            cr.accept(cv, ClassReader.EXPAND_FRAMES);
 
-        return cw.toByteArray();
+            return cw.toByteArray();
+        }
+
+        return classfileBuffer;
     }
 
 }

--- a/metrics-agent-dist/pom.xml
+++ b/metrics-agent-dist/pom.xml
@@ -55,7 +55,6 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-                            <minimizeJar>true</minimizeJar>
 							<artifactSet> 
 								<includes> 
 									<include>*:*</include> 

--- a/metrics-agent-dist/src/main/resources/log4j.properties
+++ b/metrics-agent-dist/src/main/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=WARN, stdout
+log4j.rootLogger=DEBUG, stdout
 
 log4j.appender.stdout=com.fleury.shaded.org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out


### PR DESCRIPTION
In previous version run Tomcat with the agent cause error like:
Caused by: java.lang.LinkageError: loader (instance of  sun/misc/Launcher$ExtClassLoader): attempted  duplicate class definition for name: "sun/security/mscapi/SunMSCAPI"
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:800)
....
so was classes white list added in order to operate only with target classes.
Also config file path parsing on Windows was fixed. 