### PR TITLE
Add support for nested label values

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,13 +288,3 @@ Note if you want to debug the metrics agent you should put the debugger agent fi
 
 	-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=<port> -javaagent:metrics-agent.jar myapp.jar
 
-
-# TODO
-
-Produce configuration for common use cases like Jetty server metrics. Each configurationshould be held in its own module and a build profile added to metrics-agent-dist to include that dependency.
-
-Allow specifying counted or gauged to be invoked at either method start or method end (currently only method start).
-
-Ability to capture the local variables of methods frame stack when an exception occurs and record / report to some external sink for debugging (e.g. encrypted file or server). However, this may branch into another project as it isn't monitoring, rather debugging!
-
-Implement black list support for classes we want to ignore completely for whatever reason.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ public void callService(String client)
 
 Each time this method is invoked it will use the value of the "client" parameter as the metric label value. 
 
-Note that we plan on supporting the ability to navigate object types to get child values like follows `($1.httpMethod)` where `$1` is the first method parameter and is e.g. of type HttpRequest. This means you are essentially doing `HttpRequest.getHttpMethod().toString();` We also plan on allowing access to class field values as given using `$fieldname` syntax.
+We also support accessing nested property values. For example, `($1.httpMethod)` where `$1` is the first method parameter and is e.g. of type HttpRequest. This means you are essentially doing `HttpRequest.getHttpMethod().toString();`. This nested can be arbitrarily deep.
 
 
 ## Instrumentation Metadata 

--- a/metrics-agent-core/pom.xml
+++ b/metrics-agent-core/pom.xml
@@ -42,6 +42,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>${commons.beanutils}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-util</artifactId>
             <version>${asm.version}</version>

--- a/metrics-agent-core/src/main/java/com/fleury/metrics/agent/model/LabelUtil.java
+++ b/metrics-agent-core/src/main/java/com/fleury/metrics/agent/model/LabelUtil.java
@@ -27,7 +27,19 @@ public class LabelUtil {
     }
     
     public static int getLabelVarIndex(String value) {
+        if (value.contains(".")) { //nested
+            return Integer.valueOf(value.substring(1, value.indexOf('.')));
+        }
+
         return Integer.valueOf(value.substring(1, value.length()));
+    }
+
+    public static String getNestedLabelVar(String value) {
+        return value.substring(value.indexOf('.') + 1, value.length());
+    }
+
+    public static boolean isLabelVarNested(String value) {
+        return value.contains(".");
     }
     
     public static boolean isThis(String value) {

--- a/metrics-agent-core/src/main/java/com/fleury/metrics/agent/model/LabelUtil.java
+++ b/metrics-agent-core/src/main/java/com/fleury/metrics/agent/model/LabelUtil.java
@@ -27,7 +27,7 @@ public class LabelUtil {
     }
     
     public static int getLabelVarIndex(String value) {
-        if (value.contains(".")) { //nested
+        if (isLabelVarNested(value)) {
             return Integer.valueOf(value.substring(1, value.indexOf('.')));
         }
 

--- a/metrics-agent-core/src/main/java/com/fleury/metrics/agent/model/LabelValidator.java
+++ b/metrics-agent-core/src/main/java/com/fleury/metrics/agent/model/LabelValidator.java
@@ -23,20 +23,24 @@ public class LabelValidator {
                 throwLabelInvalidException(value, "Cannot use $this.toString() in Constructor");
             }
         }
-        else if (value.startsWith("$")) {
-            if (!value.matches("\\$[0-9]+") && !value.startsWith("$this")) {
-                throwLabelInvalidException(value, "Must match pattern $[0-9]+ or start with $this");
-            }
-            
-            int index = LabelUtil.getLabelVarIndex(value);
 
-            if (index >= argTypes.length) { 
-                throwLabelInvalidException(value, "It only has " + argTypes.length + " params");
+        if (value.startsWith("$")) {
+            if (!value.matches("\\$([0-9]+|this)([a-zA-Z.]+)*")) {
+                throwLabelInvalidException(value, "Must match pattern \\\\$([0-9]+|this)([a-zA-Z.]+)* or start with $this");
             }
-            
-            Type argType = argTypes[index];
-            if (argType.getSort() == Type.ARRAY) {
-                throwLabelInvalidException(value, "ARRAY type is not allowed");
+
+            if (!value.startsWith("$this")) {
+
+                int index = LabelUtil.getLabelVarIndex(value);
+
+                if (index >= argTypes.length) {
+                    throwLabelInvalidException(value, "It only has " + argTypes.length + " params");
+                }
+
+                Type argType = argTypes[index];
+                if (argType.getSort() == Type.ARRAY) {
+                    throwLabelInvalidException(value, "ARRAY type is not allowed");
+                }
             }
         }
     }

--- a/metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/injectors/AbstractInjector.java
+++ b/metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/injectors/AbstractInjector.java
@@ -1,6 +1,8 @@
 package com.fleury.metrics.agent.transformer.asm.injectors;
 
 import static com.fleury.metrics.agent.model.LabelUtil.getLabelVarIndex;
+import static com.fleury.metrics.agent.model.LabelUtil.getNestedLabelVar;
+import static com.fleury.metrics.agent.model.LabelUtil.isLabelVarNested;
 import static com.fleury.metrics.agent.model.LabelUtil.isTemplatedLabelValue;
 import static com.fleury.metrics.agent.model.LabelUtil.isThis;
 
@@ -96,9 +98,18 @@ public abstract class AbstractInjector implements Injector, Opcodes {
 
                 boxParameterAndLoad(argIndex);
             }
-            
-            aa.visitMethodInsn(INVOKESTATIC, "java/lang/String", "valueOf",
-                        "(Ljava/lang/Object;)Ljava/lang/String;", false);
+
+            if (isLabelVarNested(labelValue)) {
+                aa.visitLdcInsn(getNestedLabelVar(labelValue));
+
+                aa.visitMethodInsn(INVOKESTATIC, "org/apache/commons/beanutils/PropertyUtils",
+                        "getNestedProperty",
+                        "(Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;", false);
+            }
+
+            aa.visitMethodInsn(INVOKESTATIC, "java/lang/String",
+                    "valueOf",
+                    "(Ljava/lang/Object;)Ljava/lang/String;", false);
         }
        
         aa.visitInsn(AASTORE);

--- a/metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injector/LabelsTest.java
+++ b/metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injector/LabelsTest.java
@@ -48,6 +48,12 @@ public class LabelsTest extends BaseMetricTest {
                 new Object[]{0, 5}, new String[]{"5"});
     }
 
+    @Test
+    public void shouldCountConstructorInvocationWithDynamicNestedValue() throws Exception {
+        testInvocationWithArgs(CountedConstructorWithDynamicNestedLabelValueClass.class,
+                new Object[]{new CountedConstructorWithDynamicNestedLabelValueClass.Nester()}, new String[]{"hello"});
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionWhenInvalidParamIndexLabelValue() throws Exception {
         testInvocationWithArgs(CountedConstructorWithInvalidParamIndexLabelValueClass.class,
@@ -144,6 +150,20 @@ public class LabelsTest extends BaseMetricTest {
 
         @Counted(name = "constructor", labels = {"name1:$1"})
         public CountedConstructorWithDynamicLongLabelValueClass(long rand, long value) {
+            BaseMetricTest.performBasicTask();
+        }
+    }
+
+    public static class CountedConstructorWithDynamicNestedLabelValueClass {
+
+        public static class Nester {
+            public String getHello() {
+                return "hello";
+            }
+        }
+
+        @Counted(name = "constructor", labels = {"name1:$0.hello"})
+        public CountedConstructorWithDynamicNestedLabelValueClass(Nester nester) {
             BaseMetricTest.performBasicTask();
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <asm.version>5.1</asm.version>
         <prometheus.version>0.0.26</prometheus.version>
         <jackson.version>2.4.0</jackson.version>
+        <commons.beanutils>1.9.3</commons.beanutils>
 
         <junit.version>4.11</junit.version>
     </properties>


### PR DESCRIPTION
Adds support for nested label values based on stack variables.

For example, `($1.httpMethod)` where `$1` is the first method parameter and is e.g. of type HttpRequest. This means you are essentially doing `HttpRequest.getHttpMethod().toString();`. This nested can be arbitrarily deep.